### PR TITLE
add local hostname feature

### DIFF
--- a/accesslog2gelf.py
+++ b/accesslog2gelf.py
@@ -12,6 +12,7 @@ parser = argparse.ArgumentParser(description='Reads apache access log on stdin a
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="Add the following to apache virtualhost configuration to use:\n" +
         'CustomLog "||/path/to/accesslog2gelf.py" "%V %h %u \\"%r\\" %>s %b \\"%{Referer}i\\""')
+parser.add_argument('--localname', dest='localname', default=None, help='local host name (default: `hostname`')
 parser.add_argument('--host', dest='host', default='localhost', help='graylog2 server hostname (default: localhost)')
 parser.add_argument('--port', dest='port', default='12201', help='graylog2 server port (default: 12201)')
 parser.add_argument('--facility', dest='facility', default='access_log', help='logging facility (default: access_log)')
@@ -31,7 +32,7 @@ if args.vhost: baserecord['vhost'] = args.vhost
 
 logger = logging.getLogger(args.facility)
 logger.setLevel(logging.DEBUG)
-logger.addHandler(graypy.GELFHandler(args.host, int(args.port), debugging_fields=False))
+logger.addHandler(graypy.GELFHandler(args.host, int(args.port), debugging_fields=False, localname=args.localname))
 
 for line in iter(sys.stdin.readline, b''):
     matches = re.search(regexp, line)

--- a/errorlog2gelf.py
+++ b/errorlog2gelf.py
@@ -12,6 +12,7 @@ parser = argparse.ArgumentParser(description='Reads apache error log on stdin an
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="Add the following to apache virtualhost configuration to use:\n" +
         'ErrorLog "||/path/to/errorlog2gelf.py')
+parser.add_argument('--localname', dest='localname', default=None, help='local host name (default: `hostname`')
 parser.add_argument('--host', dest='host', default='localhost', help='graylog2 server hostname (default: localhost)')
 parser.add_argument('--port', dest='port', default='12201', help='graylog2 server port (default: 12201)')
 parser.add_argument('--facility', dest='facility', default='access_log', help='logging facility (default: access_log)')
@@ -25,7 +26,7 @@ if args.vhost: baserecord['vhost'] = args.vhost
 
 logger = logging.getLogger(args.facility)
 logger.setLevel(logging.DEBUG)
-logger.addHandler(graypy.GELFHandler(args.host, int(args.port), debugging_fields=False))
+logger.addHandler(graypy.GELFHandler(args.host, int(args.port), debugging_fields=False, localname=args.localname))
 
 for line in iter(sys.stdin.readline, b''):
     print line.rstrip()

--- a/phplog2gelf.py
+++ b/phplog2gelf.py
@@ -16,6 +16,7 @@ from signal import signal, SIGTERM
 # https://github.com/knyar/apache2gelf
 
 parser = argparse.ArgumentParser(description='Watches php error log and delivers messages to graylog2 server via GELF')
+parser.add_argument('--localname', dest='localname', default=None, help='local host name (default: `hostname`')
 parser.add_argument('--host', dest='host', default='localhost', help='graylog2 server hostname (default: localhost)')
 parser.add_argument('--port', dest='port', default='12201', help='graylog2 server port (default: 12201)')
 parser.add_argument('--facility', dest='facility', default='php_log', help='logging facility (default: php_log)')
@@ -49,7 +50,7 @@ for thread in (thread_worker, thread_reaper):
 
 logger = logging.getLogger(args.facility)
 logger.setLevel(logging.DEBUG)
-logger.addHandler(graypy.GELFHandler(args.host, int(args.port), debugging_fields=False))
+logger.addHandler(graypy.GELFHandler(args.host, int(args.port), debugging_fields=False, localname=args.localname))
 
 record = {}
 if args.vhost: record['vhost'] = args.vhost


### PR DESCRIPTION
Add ability to specify a local hostname instead of graypy just using
gethostname().

Use: accesslog2gelf.py --localname me

This feature currently requires a patched version of graypy
(https://github.com/iggy/graypy), but I have already sent upstream a pull
request. Hopefully the patch gets in a released version soon.

Sponsored by bubbleup.net

Signed-off-by: Brian Jackson iggy@theiggy.com
