### PR TITLE
Minor fix and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Command line parameters
 -----------------------
 
 All scripts understand the following command line parameters:
+* `--localname` to specify a custom hostname
 * `--host` to specify graylog2 server
 * `--port` to specify graylog2 GELF port
 * `--facility` to specify log facility

--- a/errorlog2gelf.py
+++ b/errorlog2gelf.py
@@ -15,8 +15,8 @@ parser = argparse.ArgumentParser(description='Reads apache error log on stdin an
 parser.add_argument('--localname', dest='localname', default=None, help='local host name (default: `hostname`)')
 parser.add_argument('--host', dest='host', default='localhost', help='graylog2 server hostname (default: localhost)')
 parser.add_argument('--port', dest='port', default='12201', help='graylog2 server port (default: 12201)')
-parser.add_argument('--facility', dest='facility', default='access_log', help='logging facility (default: access_log)')
 parser.add_argument('--vhost', dest='vhost', help='Add additional "vhost" field to all log records. This can be used to differentiate between virtual hosts.')
+parser.add_argument('--facility', dest='facility', default='error_log', help='logging facility (default: access_log)')
 args = parser.parse_args()
 
 regexp = '^\[[^]]*\] \[([^]]*)\] \[client (?P<ipaddr>[0-9\.]+)\] (.*)'


### PR DESCRIPTION
errorlog2gelf facility default was access_log. Fixed that. Added --localname option to readme.
